### PR TITLE
added disableserialportaccess and set networkcreate to true

### DIFF
--- a/environments/common/common.auto.tfvars
+++ b/environments/common/common.auto.tfvars
@@ -6,7 +6,7 @@
 
 org_policies = {
   directory_customer_id = []
-  policy_boolean        = { "constraints/compute.skipDefaultNetworkCreation" = false } #constraints/compute.skipDefaultNetworkCreation = false
+  policy_boolean        = { "constraints/compute.skipDefaultNetworkCreation" = true, "constraints/compute.disableSerialPortAccess" = true } #constraints/compute.skipDefaultNetworkCreation = false
   policy_list           = {}
   setDefaultPolicy      = false # leave false for testing
   vmAllowedWithExternalIp = [


### PR DESCRIPTION
Added `disableserialportaccess` org policy to help mitigate serialport vulnerability outlined https://www.techradar.com/news/google-cloud-apparently-has-a-security-issue-even-firewalls-cant-stop.

Additionally set `skipdefaultnetworkcreation` policy to `true`