### PR TITLE
#84 - avoid common/prod collision on perimeter namespace

### DIFF
--- a/environments/common/perimeter-network.auto.tfvars
+++ b/environments/common/perimeter-network.auto.tfvars
@@ -5,7 +5,7 @@
 */
 
 public_perimeter_net = {
-  user_defined_string            = "prod" # must be globally unique
+  user_defined_string            = "prd" # must be globally unique
   additional_user_defined_string = "perim" # check 61 char aggregate limit
   billing_account                = "REPLACE_WITH_BILLING_ID" #####-#####-#####
   services                       = ["logging.googleapis.com"]

--- a/environments/prod/prod-network.auto.tfvars
+++ b/environments/prod/prod-network.auto.tfvars
@@ -6,8 +6,6 @@
 
 prod_host_net = {
   user_defined_string            = "prod" # Must be globally unique. Used to create project name
-  # cycle the following string (make it temporarily random) for now until we implement a random suffix in the following gcp_folder_suffix
-  # https://github.com/GoogleCloudPlatform/pbmm-on-gcp-onboarding/issues/44
   additional_user_defined_string = "host1"
   billing_account                = "REPLACE_WITH_BILLING_ID" ######-######-###### # required
   services                       = ["logging.googleapis.com"]


### PR DESCRIPTION
Tested as part of deploy verify on #81 
Without this change a straight copy from prod to common will experience a namespace collision