### PR TITLE
added Default logging storage location

### DIFF
--- a/environments/bootstrap/bootstrap.sh
+++ b/environments/bootstrap/bootstrap.sh
@@ -27,6 +27,7 @@ export STATE_FILE="default.tfstate"
 function run () {
  auth
  apply_roles
+ set_default_bucket
  tf_apply
  upload_statefile
  create_backends

--- a/environments/bootstrap/bootstrap.sh
+++ b/environments/bootstrap/bootstrap.sh
@@ -61,6 +61,19 @@ fi
 }
 
 ##############################################
+# Set Default Storage Bucket Region
+# Globals: 
+#  ORGID
+# Arguments: 
+#  None
+##############################################
+function set_default_bucket () {
+  ORGID=$(gcloud organizations list --format="get(name)" --filter=displayName=$DOMAIN)
+  gcloud alpha logging settings update --organization=$ORGID --storage-location=northamerica-northeast1
+
+}
+
+##############################################
 # Applies Roles based on domain and user email
 # Globals: 
 #  ORGID


### PR DESCRIPTION
Added `gcloud alpha logging settings update --organization=ORGANIZATION_ID --storage-location=LOCATION` command to `bootstrap.sh` to ensure default logs storage is in `northamerica-northeast1`.

The location is currently hard coded to `northamerica-northeast1` but we might want to open that up to be configurable by users.