### PR TITLE
#249 - interconnect initial router module

### DIFF
--- a/environments/nonprod/main.tf
+++ b/environments/nonprod/main.tf
@@ -19,6 +19,28 @@
 #                        Non-Production Network                               #
 ###############################################################################
 
+# FinOps: $8/day before partner attach
+module "partner-interconnect-primary" {
+  source   = "../../modules/20-partner-interconnect"
+  #name    = "router-1"
+  #network  = var.nonprod-interconnect.interconnect_vpc_name # "vpc-nonprod-shared" #google_compute_network.network-ia.name
+  region1   = var.nonprod-interconnect.region1
+  #project  = var.nonprod-interconnect.interconnect_router_project_id
+  interconnect_router_project_id      = module.net-host-prj.project_id
+  interconnect_vpc_name         = module.net-host-prj.network_name[var.nonprod_host_net.networks[0].network_name] 
+
+  preactivate = true
+  region1_vlan1_name = "vlan-attach-cologix-1"
+  region1_vlan2_name = "vlan-attach-cologix-2"
+  region1_vlan3_name = "vlan-attach-equinix-3"
+  region1_vlan4_name = "vlan-attach-equinix-4"
+  depends_on = [
+    data.terraform_remote_state.common,
+    module.net-host-prj,
+    module.firewall
+  ]  
+}
+
 # Module used to deploy the VPC Service control defined in nonp-vpc-svc-ctl.auto.tfvars
 module "vpc-svc-ctl" {
   source                    = "../../modules/vpc-service-controls"

--- a/environments/nonprod/nonp-interconnect.auto.tfvars
+++ b/environments/nonprod/nonp-interconnect.auto.tfvars
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+nonprod-interconnect = {
+  interconnect_vpc_name = "tzpecnr-nonprod-svpc-vpc"
+  interconnect_router_project_id = "tzpe-tlz-tlz-np2"
+
+  # currently defaulted - uncomment to set
+  region1 = "northamerica-northeast1"
+
+  preactivate = true
+
+  region1_vlan1_name = "vlan-attach-cologix-1"
+  region1_vlan2_name = "vlan-attach-cologix-2"
+  region1_vlan3_name = "vlan-attach-equinix-3"
+  region1_vlan4_name = "vlan-attach-equinix-4"
+}

--- a/environments/nonprod/variables.tf
+++ b/environments/nonprod/variables.tf
@@ -16,7 +16,22 @@
 
 
 
+variable nonprod-interconnect {
+        type = object({
+  interconnect_vpc_name = string
+  interconnect_router_project_id = string
 
+  # currently defaulted - uncomment to set
+  region1 = string
+
+  preactivate = bool
+
+  region1_vlan1_name = string
+  region1_vlan2_name = string
+  region1_vlan3_name = string
+  region1_vlan4_name = string
+    })
+}
 
 variable "tf_service_account_email" {
   type        = string

--- a/modules/20-partner-interconnect/main.tf
+++ b/modules/20-partner-interconnect/main.tf
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/******************************************
+  Partner Interconnect
+*****************************************/
+
+# start with https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_interconnect_attachment
+
+/*locals {
+  suffix1 = lookup(var.cloud_router_labels, "vlan_1", "cr1")
+  suffix2 = lookup(var.cloud_router_labels, "vlan_2", "cr2")
+}*/
+/*
+resource "google_compute_interconnect_attachment" "on_prem1" {
+  name                     = var.region1_vlan1_name
+  #name = "vl-${var.region1_interconnect1_onprem_dc}-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}-${local.suffix1}"
+  edge_availability_domain = "AVAILABILITY_DOMAIN_1"
+  type                     = "PARTNER"
+  router                   = google_compute_router.router1.id
+  region = var.region1
+  mtu                      = 1500
+  admin_enabled            = var.preactivate
+}
+
+resource "google_compute_interconnect_attachment" "on_prem2" {
+  name                     = var.region1_vlan2_name
+  edge_availability_domain = "AVAILABILITY_DOMAIN_2"
+  type                     = "PARTNER"
+  router                   = google_compute_router.router1.id
+  region = var.region1
+  mtu                      = 1500
+  admin_enabled            = var.preactivate
+}
+
+resource "google_compute_interconnect_attachment" "on_prem3" {
+  name                     = var.region1_vlan3_name
+  edge_availability_domain = "AVAILABILITY_DOMAIN_1"
+  type                     = "PARTNER"
+  router                   = google_compute_router.router1.id
+  region = var.region1
+  mtu                      = 1500
+  admin_enabled            = var.preactivate
+}
+
+resource "google_compute_interconnect_attachment" "on_prem4" {
+  name                     = var.region1_vlan4_name
+  edge_availability_domain = "AVAILABILITY_DOMAIN_2"
+  type                     = "PARTNER"
+  router                   = google_compute_router.router1.id
+  region = var.region1
+  mtu                      = 1500
+  admin_enabled            = var.preactivate
+}
+*/
+resource "google_compute_router" "router1" {
+  name    = "router-1"
+  network = var.interconnect_vpc_name # "vpc-nonprod-shared" #google_compute_network.network-ia.name
+  region = var.region1
+  project = var.interconnect_router_project_id
+  bgp {
+    asn = 16550
+  }
+}

--- a/modules/20-partner-interconnect/outputs.tf
+++ b/modules/20-partner-interconnect/outputs.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+output "on_prem1" {
+  value       = google_compute_interconnect_attachment.on_prem1
+  description = "The interconnect attachment 1 for region 1"
+}
+
+output "on_prem2" {
+  value       = google_compute_interconnect_attachment.on_prem2
+  description = "The interconnect attachment 2 for region 1"
+}*/
+
+output "router1" {
+  value       = google_compute_router.router1
+  description = "The router for all attachements in the particular region"
+}

--- a/modules/20-partner-interconnect/variables.tf
+++ b/modules/20-partner-interconnect/variables.tf
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "interconnect_router_project_id" {
+  type        = string
+  description = "project hosting the interconnect."
+}
+
+variable "interconnect_vpc_name" {
+  type        = string
+  description = "Label to identify the VPC associated with shared VPC that will use the Interconnect."
+}
+
+variable "region1" {
+  type        = string
+  description = "First subnet region. The Partner Interconnect module only configures two regions."
+  default = "northamerica-northeast1"
+}
+
+variable "region1_router1_name" {
+  type        = string
+  description = "Name of the Router 1 for Region 1 where the attachment resides."
+  default = "router1"
+}
+
+variable "region1_router2_name" {
+  type        = string
+  description = "Name of the Router 2 for Region 1 where the attachment resides."
+  default = "router2"
+}
+
+variable "region1_vlan1_name" {
+  type        = string
+  description = "Name of the VLAN 1 for Region 1 where the attachment resides."
+  default = "vlan-attach-1"
+}
+
+variable "region1_vlan2_name" {
+  type        = string
+  description = "Name of the VLAN 2 for Region 1 where the attachment resides."
+  default = "vlan-attach-2"
+}
+
+variable "region1_vlan3_name" {
+  type        = string
+  description = "Name of the VLAN 3 for Region 1 where the attachment resides."
+  default = "vlan-attach-3"
+}
+
+variable "region1_vlan4_name" {
+  type        = string
+  description = "Name of the VLAN 4 for Region 1 where the attachment resides."
+  default = "vlan-attach-4"
+}
+/*variable "cloud_router_labels" {
+  type        = map(string)
+  description = "A map of suffixes for labelling vlans with four entries like \"vlan_1\" => \"suffix1\" with keys from `vlan_1` to `vlan_4`."
+  default     = {}
+}*/
+
+variable "preactivate" {
+  description = "Preactivate Partner Interconnect attachments, works only for level3 Partner Interconnect"
+  type        = string
+  default     = false
+}


### PR DESCRIPTION
Initial partner interconnect module with root main usage.
Router implemented first
Interconnects second
along with finished output/variable pipelining

Test results on a pbmm.landing.systems deployment 

```
Step #3 - "tf plan": Terraform will perform the following actions:
Step #3 - "tf plan": 
Step #3 - "tf plan":   # module.partner-interconnect-primary.google_compute_router.router1 will be created
Step #3 - "tf plan":   + resource "google_compute_router" "router1" {
Step #3 - "tf plan":       + creation_timestamp = (known after apply)
Step #3 - "tf plan":       + id                 = (known after apply)
Step #3 - "tf plan":       + name               = "router-1"
Step #3 - "tf plan":       + network            = "tzpecnr-nonprod-svpc-vpc"
Step #3 - "tf plan":       + project            = "tzpe-tlz-tlz-np2"
Step #3 - "tf plan":       + region             = "northamerica-northeast1"
Step #3 - "tf plan":       + self_link          = (known after apply)
Step #3 - "tf plan": 
Step #3 - "tf plan":       + bgp {
Step #3 - "tf plan":           + advertise_mode = "DEFAULT"
Step #3 - "tf plan":           + asn            = 16550
Step #3 - "tf plan":         }
Step #3 - "tf plan":     }


Step #4 - "tf apply": *************** TERRAFORM APPLY ******************
Step #4 - "tf apply": ******* At environment: environments/nonprod ***********
Step #4 - "tf apply": *************************************************
Step #4 - "tf apply": module.net-host-prj.module.network["nonprod-svpc"].module.subnets["npsubnet02"].google_compute_subnetwork.subnetwork: Modifying... [id=projects/tzpe-tlz-tlz-np2/regions/northamerica-northeast1/subnetworks/tzpecnr-npsubnet02-np2-snet]
Step #4 - "tf apply": module.net-host-prj.module.network["nonprod-svpc"].module.subnets["npsubnet02"].google_compute_subnetwork.subnetwork: Modifications complete after 1s [id=projects/tzpe-tlz-tlz-np2/regions/northamerica-northeast1/subnetworks/tzpecnr-npsubnet02-np2-snet]
Step #4 - "tf apply": module.partner-interconnect-primary.google_compute_router.router1: Creating...
Step #4 - "tf apply": module.partner-interconnect-primary.google_compute_router.router1: Still creating... [10s elapsed]
Step #4 - "tf apply": module.partner-interconnect-primary.google_compute_router.router1: Still creating... [20s elapsed]
Step #4 - "tf apply": module.partner-interconnect-primary.google_compute_router.router1: Creation complete after 22s [id=projects/tzpe-tlz-tlz-np2/regions/northamerica-northeast1/routers/router-1]
Step #4 - "tf apply": ╷
```