### PR TITLE
Making scc-notification ID randomizable org-level to allow deploying multiple TEF instances same org

### DIFF
--- a/1-org/envs/shared/outputs.tf
+++ b/1-org/envs/shared/outputs.tf
@@ -20,7 +20,7 @@ output "org_id" {
 }
 
 output "scc_notification_name" {
-  value       = var.scc_notification_name
+  value = local.scc_notification_name
   description = "Name of SCC Notification"
 }
 

--- a/1-org/envs/shared/scc_notification.tf
+++ b/1-org/envs/shared/scc_notification.tf
@@ -18,6 +18,16 @@
   SCC Notification
 *****************************************/
 
+// MRo: randomize SCC notification name to avoid org-level naming conflicts
+locals {
+    scc_notification_suffix  = var.create_unique_scc_notification ? "-${random_string.scc_notification_key_suffix.result}" : ""
+    scc_notification_name    = "${var.scc_notification_name}${local.scc_notification_suffix}"
+}
+resource "random_string" "scc_notification_key_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
 resource "google_pubsub_topic" "scc_notification_topic" {
   name    = "top-scc-notification"
   project = module.scc_notifications.project_id
@@ -30,7 +40,7 @@ resource "google_pubsub_subscription" "scc_notification_subscription" {
 }
 
 resource "google_scc_notification_config" "scc_notification_config" {
-  config_id    = var.scc_notification_name
+  config_id    = local.scc_notification_name
   organization = local.org_id
   description  = "SCC Notification for all active findings"
   pubsub_topic = google_pubsub_topic.scc_notification_topic.id

--- a/1-org/envs/shared/variables.tf
+++ b/1-org/envs/shared/variables.tf
@@ -30,6 +30,12 @@ variable "scc_notification_name" {
   type        = string
 }
 
+// MRo: if true create unique SCC notification name
+variable "create_unique_scc_notification" {
+  description = "Set to true to append an unique suffix to the SCC notification name and avoid org-level naming conflicts."
+  type        = bool
+  default     = false
+}
 variable "create_access_context_manager_access_policy" {
   description = "Whether to create access context manager access policy."
   type        = bool


### PR DESCRIPTION
There are 2 org-level resources with hardcoded IDs - tags and SCC notifications
For tags name randomization support already available - just put in 1-org/envs/shared/terraform.mod.tfvars  create_unique_tag_key = true (default)
Similar mechanism for SCC notifications - enable uniqueness via randomization by setting create_unique_scc_notification = true in the same file