### PR TITLE
Fix bucket name length and make random suffix length variable for the hierarchical firewall

### DIFF
--- a/1-org/modules/cai-monitoring/main.tf
+++ b/1-org/modules/cai-monitoring/main.tf
@@ -27,6 +27,8 @@ locals {
     "eventarc.googleapis.com"
   ]
   cai_source_name = var.random_suffix ? "CAI Monitoring - ${random_id.suffix.hex}" : "CAI Monitoring"
+  ## MRo:
+  cai_monitoring_bucket_suffix = "${random_id.suffix.hex}-sources-${data.google_project.project.number}-${var.location}"
 }
 
 data "google_project" "project" {
@@ -74,7 +76,9 @@ module "cloudfunction_source_bucket" {
   version = "~> 5.0"
 
   project_id    = var.project_id
-  name          = "bkt-cai-monitoring-${random_id.suffix.hex}-sources-${data.google_project.project.number}-${var.location}"
+  ## MRo:
+  ##  name          = "bkt-cai-monitoring-${random_id.suffix.hex}-sources-${data.google_project.project.number}-${var.location}"
+  name          = "bkt-cai-monitoring-${md5(local.cai_monitoring_bucket_suffix)}"
   location      = var.location
   storage_class = "REGIONAL"
   force_destroy = true

--- a/3-networks-dual-svpc/modules/hierarchical_firewall_policy/main.tf
+++ b/3-networks-dual-svpc/modules/hierarchical_firewall_policy/main.tf
@@ -19,7 +19,8 @@ locals {
 }
 
 resource "random_string" "suffix" {
-  length  = 4
+  // allow configurable random suffix length
+  length  = var.random_string_length
   upper   = false
   special = false
 }

--- a/3-networks-dual-svpc/modules/hierarchical_firewall_policy/variables.tf
+++ b/3-networks-dual-svpc/modules/hierarchical_firewall_policy/variables.tf
@@ -44,3 +44,9 @@ variable "associations" {
   description = "Resources to associate the policy to"
   type        = list(string)
 }
+// allow configurable random suffix length
+variable "random_string_length" {
+  description = "Sets the length of `random suffix` to the provided length"
+  type        = number
+  default     = 4
+}

--- a/3-networks-hub-and-spoke/envs/shared/hierarchical_firewall.tf
+++ b/3-networks-hub-and-spoke/envs/shared/hierarchical_firewall.tf
@@ -19,7 +19,7 @@ module "hierarchical_firewall_policy" {
 
   parent = local.common_folder_name
   name   = "common-firewall-rules"
-  associations = [
+   associations = [
     local.common_folder_name,
     local.network_folder_name,
     local.bootstrap_folder_name,

--- a/3-networks-hub-and-spoke/modules/hierarchical_firewall_policy/main.tf
+++ b/3-networks-hub-and-spoke/modules/hierarchical_firewall_policy/main.tf
@@ -19,7 +19,8 @@ locals {
 }
 
 resource "random_string" "suffix" {
-  length  = 4
+  // allow configurable random suffix length
+  length  = var.random_string_length
   upper   = false
   special = false
 }

--- a/3-networks-hub-and-spoke/modules/hierarchical_firewall_policy/variables.tf
+++ b/3-networks-hub-and-spoke/modules/hierarchical_firewall_policy/variables.tf
@@ -44,3 +44,9 @@ variable "associations" {
   description = "Resources to associate the policy to"
   type        = list(string)
 }
+// allow configurable random suffix length
+variable "random_string_length" {
+  description = "Sets the length of `random suffix` to the provided length"
+  type        = number
+  default     = 4
+}

--- a/4-projects/modules/base_env/example_storage_cmek.tf
+++ b/4-projects/modules/base_env/example_storage_cmek.tf
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// MRo: fix GCS bucket name too long
+locals {
+  cmek_bucket_suffix = "${module.base_shared_vpc_project.project_id}-${lower(var.location_gcs)}-${random_string.bucket_name.result}"
+  cmek_bucket_prefix = "${var.gcs_bucket_prefix}-cmek-encrypted"
 
+}
 module "env_kms_project" {
   source = "../single_project"
 
@@ -69,7 +74,9 @@ module "gcs_buckets" {
 
   project_id         = module.base_shared_vpc_project.project_id
   location           = var.location_gcs
-  name               = "${var.gcs_bucket_prefix}-${module.base_shared_vpc_project.project_id}-${lower(var.location_gcs)}-cmek-encrypted-${random_string.bucket_name.result}"
+  // MRo: over 63 chars
+  //name               = "${var.gcs_bucket_prefix}-${module.base_shared_vpc_project.project_id}-${lower(var.location_gcs)}-cmek-encrypted-${random_string.bucket_name.result}"
+  name               = "${local.cmek_bucket_prefix}-${md5(local.cmek_bucket_suffix)}"
   bucket_policy_only = true
 
   encryption = {


### PR DESCRIPTION
For the GCS bucket aggregate the previous variable length suffix (which may end up in violating the max 63 chars rule) into a fixed length md5 string - this way the bucket name length is always the same regardless of the region name. Can be imbroved by passing the md5 through a base64 finction to reduce suffix length

Also incorporated for the hierarchical FW variable random suffix length (devault still 4)